### PR TITLE
Don't regenerate image id when unnecessary

### DIFF
--- a/scripts/simplify.py
+++ b/scripts/simplify.py
@@ -22,7 +22,7 @@ element_format_rules = {
 		'default_styles': {
 			'style': 'display:inline'
 		},
-		'allowed_attrs': ['x', 'y', 'width', 'height', 'xlink:href', 'preserveAspectRatio'],
+		'allowed_attrs': ['x', 'y', 'width', 'height', 'xlink:href', 'preserveAspectRatio', 'id'],
 		'element_tag': 'image',
 		'id_subfix': 'image_'
 	},


### PR DESCRIPTION
When working on #14 I noticed that the script keeps changing the `id` attribute of `image` objects, even when the id was already there and no change was made. I manually reverted the changes there, but took a look today why this happens. `simplify.py` removes the attribute from images because `id` is not listed in `allowed_attrs`, but then notices that there is no id and generates a new one. This change adds `id` to `allowed_attrs`, so this doesn't happen anymore.